### PR TITLE
[RFR] Aruco channels for botui

### DIFF
--- a/include/wallaby/aruco.hpp
+++ b/include/wallaby/aruco.hpp
@@ -34,6 +34,7 @@ public:
   bool arucoMarkerInView(int arucoId, cv::Mat * frame = nullptr);
   bool setDictionary(int dictionaryId);
   std::vector<int> arucoMarkersInView(cv::Mat * frame = nullptr);
+  std::vector<std::vector<cv::Point2f>> arucoMarkerCorners(cv::Mat * frame = nullptr);
   std::vector<double> getPose(int arucoId, cv::Mat * frame = nullptr);
   void setChessBoardSize(float sizeInMeters);
   void setArucoMarkerSize(float sizeInMeters);

--- a/include/wallaby/aruco.hpp
+++ b/include/wallaby/aruco.hpp
@@ -31,10 +31,10 @@ public:
   Aruco(int dicionaryId);
   ~Aruco();
   static Aruco *getInstance();
-  bool arucoMarkerInView(int arucoId);
+  bool arucoMarkerInView(int arucoId, cv::Mat * frame = nullptr);
   bool setDictionary(int dictionaryId);
-  std::vector<int> arucoMarkersInView();
-  std::vector<double> getPose(int arucoId);
+  std::vector<int> arucoMarkersInView(cv::Mat * frame = nullptr);
+  std::vector<double> getPose(int arucoId, cv::Mat * frame = nullptr);
   void setChessBoardSize(float sizeInMeters);
   void setArucoMarkerSize(float sizeInMeters);
   bool calibrate(std::vector<cv::Mat> images);

--- a/include/wallaby/camera.hpp
+++ b/include/wallaby/camera.hpp
@@ -29,7 +29,7 @@
 
 #define CAMERA_CHANNEL_TYPE_HSV_KEY ("hsv")
 #define CAMERA_CHANNEL_TYPE_QR_KEY ("qr")
-#define CAMERA_CHANNEL_TYPE_ARUCO_KE Y ("aruco")
+#define CAMERA_CHANNEL_TYPE_ARUCO_KEY ("aruco")
 
 namespace cv {
 class VideoCapture;

--- a/include/wallaby/camera.hpp
+++ b/include/wallaby/camera.hpp
@@ -29,6 +29,7 @@
 
 #define CAMERA_CHANNEL_TYPE_HSV_KEY ("hsv")
 #define CAMERA_CHANNEL_TYPE_QR_KEY ("qr")
+#define CAMERA_CHANNEL_TYPE_ARUCO_KE Y ("aruco")
 
 namespace cv {
 class VideoCapture;

--- a/src/aruco.cpp
+++ b/src/aruco.cpp
@@ -162,7 +162,7 @@ bool aruco::Aruco::vectorContains(std::vector<int> vec, int val) {
  * returns as TX TY TZ RX RY RZ
  *
  */
-std::vector<double> aruco::Aruco::getPose(int arucoId) {
+std::vector<double> aruco::Aruco::getPose(int arucoId, cv::Mat * frame) {
   std::vector<double> rottransvec;
   rottransvec.assign(6, 0.0);
   // Camera Calibration Failed...No files?
@@ -171,13 +171,22 @@ std::vector<double> aruco::Aruco::getPose(int arucoId) {
        cv::countNonZero(distortionCoefficients) < 1))
     return rottransvec;
 
-  if (!this->m_camDevice->isOpen())
-    if (!this->openCamera())
-      return rottransvec;
-  cv::Mat img = this->getFrame();
+  cv::Mat img;
+  if (frame == nullptr){
+    if (!this->m_camDevice->isOpen())
+      if (!this->openCamera())
+        return rottransvec;
+    img = this->getFrame();
+  }else
+  {
+    img = *frame;
+  }
+
+
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners, rejected;
   std::vector<cv::Vec3d> rvecs, tvecs;
+
 
   // detect markers and estimate pose
   cv::aruco::detectMarkers(img, this->dictionary, corners, ids, detectorParams,
@@ -207,15 +216,23 @@ std::vector<double> aruco::Aruco::getPose(int arucoId) {
  * Get an array (vector) of all Aruco Markers in the current view
  *
  */
-std::vector<int> aruco::Aruco::arucoMarkersInView() {
+std::vector<int> aruco::Aruco::arucoMarkersInView(cv::Mat * frame) {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners, rejected;
-  if (!this->m_camDevice->isOpen())
-    if (!this->openCamera())
-      return ids;
-  cv::Mat img = this->getFrame();
+  cv::Mat img;
+  if (frame == nullptr){
+    if (!this->m_camDevice->isOpen())
+      if (!this->openCamera())
+        return ids;
+    img = this->getFrame();
+  }else
+  {
+    img = *frame;
+  }
+
   cv::aruco::detectMarkers(img, this->dictionary, corners, ids, detectorParams,
                            rejected);
+
   return ids;
 }
 
@@ -225,13 +242,19 @@ std::vector<int> aruco::Aruco::arucoMarkersInView() {
  * Check if a particular Aruco Marker is in the current view
  *
  */
-bool aruco::Aruco::arucoMarkerInView(int arucoId) {
+bool aruco::Aruco::arucoMarkerInView(int arucoId, cv::Mat * frame) {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners, rejected;
-  if (!this->m_camDevice->isOpen())
-    if (!this->openCamera())
-      return false;
-  cv::Mat img = this->getFrame();
+  cv::Mat img;
+  if (frame == nullptr){
+    if (!this->m_camDevice->isOpen())
+      if (!this->openCamera())
+        return false;
+    img = this->getFrame();
+  }else
+  {
+    img = *frame;
+  }
   cv::aruco::detectMarkers(img, this->dictionary, corners, ids, detectorParams,
                            rejected);
   if (find(ids.begin(), ids.end(), arucoId) != ids.end())

--- a/src/aruco.cpp
+++ b/src/aruco.cpp
@@ -32,6 +32,8 @@ aruco::Aruco::Aruco(int dictionaryId) {
     this->readCameraCalibration(this->currentCalibrationFile);
   }
   this->m_camDevice = new Camera::Device();
+  std::cout << "Aruco constructor" << std::endl;
+  // TODO: ??? this->m_camDevice->open(0, LOW_RES, BLACK_2017);
 }
 
 /*
@@ -208,9 +210,16 @@ std::vector<double> aruco::Aruco::getPose(int arucoId) {
 std::vector<int> aruco::Aruco::arucoMarkersInView() {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners, rejected;
+<<<<<<< 889d39bd6b8fb9c04b97aae05691e307a159b21f
   if (!this->m_camDevice->isOpen())
     if (!this->openCamera())
       return ids;
+=======
+  if(!this->m_camDevice->isOpen()){
+      std::cout << "camera is not open" << std::endl;
+      return ids;
+  }
+>>>>>>> Adding debug info and todos
   cv::Mat img = this->getFrame();
   cv::aruco::detectMarkers(img, this->dictionary, corners, ids, detectorParams,
                            rejected);

--- a/src/aruco.cpp
+++ b/src/aruco.cpp
@@ -235,6 +235,32 @@ std::vector<int> aruco::Aruco::arucoMarkersInView(cv::Mat * frame) {
 }
 
 /*
+ * Marker corners in view
+ *
+ */
+std::vector<std::vector<cv::Point2f>> aruco::Aruco::arucoMarkerCorners(cv::Mat * frame)
+{
+  std::vector<int> ids;
+  std::vector<std::vector<cv::Point2f>> corners, rejected;
+
+  cv::Mat img;
+  if (frame == nullptr) {
+    if (!this->m_camDevice->isOpen())
+      if (!this->openCamera())
+        return corners;
+    img = this->getFrame();
+  } else {
+    img = *frame;
+  }
+
+    cv::aruco::detectMarkers(img, this->dictionary, corners, ids, detectorParams,
+                           rejected);
+
+  return corners;
+}
+
+
+/*
  * Marker In View
  *
  * Check if a particular Aruco Marker is in the current view

--- a/src/aruco.cpp
+++ b/src/aruco.cpp
@@ -210,16 +210,9 @@ std::vector<double> aruco::Aruco::getPose(int arucoId) {
 std::vector<int> aruco::Aruco::arucoMarkersInView() {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners, rejected;
-<<<<<<< 889d39bd6b8fb9c04b97aae05691e307a159b21f
   if (!this->m_camDevice->isOpen())
     if (!this->openCamera())
       return ids;
-=======
-  if(!this->m_camDevice->isOpen()){
-      std::cout << "camera is not open" << std::endl;
-      return ids;
-  }
->>>>>>> Adding debug info and todos
   cv::Mat img = this->getFrame();
   cv::aruco::detectMarkers(img, this->dictionary, corners, ids, detectorParams,
                            rejected);

--- a/src/aruco.cpp
+++ b/src/aruco.cpp
@@ -172,13 +172,12 @@ std::vector<double> aruco::Aruco::getPose(int arucoId, cv::Mat * frame) {
     return rottransvec;
 
   cv::Mat img;
-  if (frame == nullptr){
+  if (frame == nullptr) {
     if (!this->m_camDevice->isOpen())
       if (!this->openCamera())
         return rottransvec;
     img = this->getFrame();
-  }else
-  {
+  } else {
     img = *frame;
   }
 
@@ -220,13 +219,12 @@ std::vector<int> aruco::Aruco::arucoMarkersInView(cv::Mat * frame) {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners, rejected;
   cv::Mat img;
-  if (frame == nullptr){
+  if (frame == nullptr) {
     if (!this->m_camDevice->isOpen())
       if (!this->openCamera())
         return ids;
     img = this->getFrame();
-  }else
-  {
+  } else {
     img = *frame;
   }
 
@@ -246,13 +244,12 @@ bool aruco::Aruco::arucoMarkerInView(int arucoId, cv::Mat * frame) {
   std::vector<int> ids;
   std::vector<std::vector<cv::Point2f>> corners, rejected;
   cv::Mat img;
-  if (frame == nullptr){
+  if (frame == nullptr) {
     if (!this->m_camDevice->isOpen())
       if (!this->openCamera())
         return false;
     img = this->getFrame();
-  }else
-  {
+  } else {
     img = *frame;
   }
   cv::aruco::detectMarkers(img, this->dictionary, corners, ids, detectorParams,

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -96,8 +96,10 @@ ObjectVector ChannelImpl::objects(const Config &config) {
 }
 
 std::map<std::string, ChannelImpl *> ChannelImplManager::m_channelImpls = {
-    {"hsv", new Private::Camera::HsvChannelImpl()},
-    {"qr", new Private::Camera::BarcodeChannelImpl}};
+  {"hsv", new Private::Camera::HsvChannelImpl()}, 
+  {"qr", new Private::Camera::BarcodeChannelImpl()},
+  {"aruco", new Private::Camera::ArucoChannelImpl()}
+};
 
 void ChannelImplManager::setImage(const cv::Mat &image) {
   std::map<std::string, ChannelImpl *>::iterator it = m_channelImpls.begin();

--- a/src/channel_p.cpp
+++ b/src/channel_p.cpp
@@ -154,7 +154,7 @@ void ArucoChannelImpl::update(const cv::Mat &image)
   
   // TODO: actual aruco image format needs
 
-   m_image = image
+   m_image = image;
 }
 
 Camera::ObjectVector ArucoChannelImpl::findObjects(const Config &config)

--- a/src/channel_p.cpp
+++ b/src/channel_p.cpp
@@ -162,7 +162,7 @@ Camera::ObjectVector ArucoChannelImpl::findObjects(const Config &config)
   if(m_image.empty()) return ::Camera::ObjectVector();
   
   // TODO: use m_image, don't get a new image
-  std::cout << "We see " << aruco::Aruco::getInstance()->arucoMarkersInView().size() << " markers" << std::endl;
+  std::cout << "We see " << aruco::Aruco::getInstance()->arucoMarkersInView(&m_image).size() << " markers" << std::endl;
 
   // TODO: find aruco markers and fill ret in  
   return ::Camera::ObjectVector();

--- a/src/channel_p.cpp
+++ b/src/channel_p.cpp
@@ -11,6 +11,9 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include <zbar.h>
+#include <iostream> 
+#include "wallaby/aruco.hpp"
+
 
 using namespace Private::Camera;
 
@@ -157,7 +160,8 @@ void ArucoChannelImpl::update(const cv::Mat &image)
 Camera::ObjectVector ArucoChannelImpl::findObjects(const Config &config)
 {
   if(m_image.empty()) return ::Camera::ObjectVector();
-  
+  std::cout << "We see " << aruco::Aruco::getInstance()->arucoMarkersInView().size() << " markers" << std::endl;
+
   // TODO: find aruco markers and fill ret in  
   return ::Camera::ObjectVector();
 }

--- a/src/channel_p.cpp
+++ b/src/channel_p.cpp
@@ -154,12 +154,14 @@ void ArucoChannelImpl::update(const cv::Mat &image)
   
   // TODO: actual aruco image format needs
 
-  cv::cvtColor(image, m_image, cv::COLOR_BGR2HSV);
+   m_image = image
 }
 
 Camera::ObjectVector ArucoChannelImpl::findObjects(const Config &config)
 {
   if(m_image.empty()) return ::Camera::ObjectVector();
+  
+  // TODO: use m_image, don't get a new image
   std::cout << "We see " << aruco::Aruco::getInstance()->arucoMarkersInView().size() << " markers" << std::endl;
 
   // TODO: find aruco markers and fill ret in  

--- a/src/channel_p.cpp
+++ b/src/channel_p.cpp
@@ -137,3 +137,27 @@ void BarcodeChannelImpl::update(const cv::Mat &image)
   
   return ret;
 }
+
+ArucoChannelImpl::ArucoChannelImpl()
+{
+}
+
+void ArucoChannelImpl::update(const cv::Mat &image)
+{
+  if(image.empty()) {
+    m_image = cv::Mat();
+    return;
+  }
+  
+  // TODO: actual aruco image format needs
+
+  cv::cvtColor(image, m_image, cv::COLOR_BGR2HSV);
+}
+
+Camera::ObjectVector ArucoChannelImpl::findObjects(const Config &config)
+{
+  if(m_image.empty()) return ::Camera::ObjectVector();
+  
+  // TODO: find aruco markers and fill ret in  
+  return ::Camera::ObjectVector();
+}

--- a/src/channel_p.hpp
+++ b/src/channel_p.hpp
@@ -40,6 +40,17 @@ namespace Private
       zbar::Image m_image;
       zbar::ImageScanner m_scanner;
     };
+
+    class ArucoChannelImpl : public ::Camera::ChannelImpl
+    {
+    public:
+      ArucoChannelImpl();
+      virtual void update(const cv::Mat &image);
+      virtual ::Camera::ObjectVector findObjects(const Config &config);
+
+    private:
+      cv::Mat m_image;
+    };
   }
 }
 


### PR DESCRIPTION
@ryanvade  This isn't ready yet.  I am handling aruco channels compatible with   https://github.com/kipr/botui/pull/32

For now the aruco channels are just outputting to the terminal how many markers are recognized:
https://github.com/ryanvade/libwallaby/compare/aruco...jsoutherland:aruco-botui-channels?expand=1#diff-ed5f5b6296dd7f9c19afd14912581154R163

I haven't seen it recognize a marker yet.
I tried marker5.png  which I believe is the same one you are using for the aruco test:
![marker5](https://cloud.githubusercontent.com/assets/1850915/25021032/5521cd48-2056-11e7-8a70-47f97ccc7894.png)
I generated it via https://github.com/ryanvade/aruco-raspi3/blob/devel/src/Util/generateMarkers.cpp

Once matches are returned my next todo would be to return image-space coordinates here:
https://github.com/ryanvade/libwallaby/compare/aruco...jsoutherland:aruco-botui-channels?expand=1#diff-ed5f5b6296dd7f9c19afd14912581154R166

which will cause a bounding box around each marker in botui.      I would start with a small box  like 4x4 pixels and then either use scale info or update botui to display axes based on orientation info from aruco.
